### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ of Arturo.
 
     $ rails g arturo:migration
     $ rails g arturo:initializer
-    $ rails g arturo:route
+    $ rails g arturo:routes
     $ rails g arturo:assets
 
 #### Run the migration:


### PR DESCRIPTION
There was a typo in the README. The correct generator apparently ends in 's'.
