### PR TITLE
make FeatureCaching::Cache not convert all keys to strings to reflect what a more stupid cache could do

### DIFF
--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -31,15 +31,15 @@ module Arturo
 
     # Wraps Arturo::Feature.to_feature with in-memory caching.
     def to_feature_with_caching(feature_or_symbol)
-      if !self.caches_features?
-        return to_feature_without_caching(feature_or_symbol)
+      if !caches_features?
+        to_feature_without_caching(feature_or_symbol)
       elsif (feature_or_symbol.kind_of?(Arturo::Feature))
-        feature_cache.write(feature_or_symbol.symbol, feature_or_symbol, :expires_in => cache_ttl)
+        feature_cache.write(feature_or_symbol.symbol.to_sym, feature_or_symbol, :expires_in => cache_ttl)
         feature_or_symbol
       elsif (cached_feature = feature_cache.read(feature_or_symbol.to_sym))
         cached_feature
       elsif (f = to_feature_without_caching(feature_or_symbol))
-        feature_cache.write(f.symbol, f, :expires_in => cache_ttl)
+        feature_cache.write(f.symbol.to_sym, f, :expires_in => cache_ttl)
         f
       end
     end
@@ -51,8 +51,8 @@ module Arturo
       def initialize
         @data = {} # of the form {key => [value, expires_at or nil]}
       end
+
       def read(name, options = nil)
-        name = name.to_s
         value, expires_at = *@data[name]
         if value && (expires_at.blank? || expires_at > Time.now)
           value
@@ -60,8 +60,8 @@ module Arturo
           nil
         end
       end
+
       def write(name, value, options = nil)
-        name = name.to_s
         expires_at = if options && options.respond_to?(:[]) && options[:expires_in]
           Time.now + options.delete(:expires_in)
         else
@@ -71,6 +71,7 @@ module Arturo
           @data[name] = [value, expires_at]
         end
       end
+
       def clear
         @data.clear
       end

--- a/test/dummy_app/test/unit/cache_test.rb
+++ b/test/dummy_app/test/unit/cache_test.rb
@@ -5,6 +5,20 @@ class CacheTest < ActiveSupport::TestCase
 
   Arturo::Feature.extend(Arturo::FeatureCaching)
 
+  class StupidCache
+    def initialize
+      @data = {}
+    end
+
+    def read(key)
+      @data[key]
+    end
+
+    def write(key, value, options={})
+      @data[key] = value
+    end
+  end
+
   def setup
     @feature = Factory(:feature)
     Arturo::Feature.cache_ttl = 30.minutes
@@ -17,34 +31,43 @@ class CacheTest < ActiveSupport::TestCase
   end
 
   def test_first_load_hits_database
-    Arturo::Feature.expects(:where).once.returns([@feature])
+    Arturo::Feature.expects(:where).once.returns([@feature.reload])
     Arturo::Feature.to_feature(@feature.symbol)
   end
 
   def test_subsequent_loads_within_ttl_hit_cache
-    Arturo::Feature.expects(:where).once.returns([@feature])
+    Arturo::Feature.expects(:where).once.returns([@feature.reload])
     Arturo::Feature.to_feature(@feature.symbol)
     Arturo::Feature.to_feature(@feature.symbol)
+    Arturo::Feature.to_feature(@feature.symbol)
+  end
+
+  def test_works_with_other_cache_backend
+    Arturo::Feature.feature_cache = StupidCache.new
+    Arturo::Feature.expects(:where).once.returns([@feature.reload])
+    Arturo::Feature.to_feature(@feature.symbol.to_sym)
+    Arturo::Feature.to_feature(@feature.symbol)
+    Arturo::Feature.to_feature(@feature.symbol.to_sym)
     Arturo::Feature.to_feature(@feature.symbol)
   end
 
   def test_clear_cache
     Arturo::Feature.to_feature(@feature.symbol)
     Arturo::Feature.feature_cache.clear
-    Arturo::Feature.expects(:where).once.returns([@feature])
+    Arturo::Feature.expects(:where).once.returns([@feature.reload])
     Arturo::Feature.to_feature(@feature.symbol)
   end
 
   def test_turn_off_caching
     Arturo::Feature.cache_ttl = 0
-    Arturo::Feature.expects(:where).twice.returns([@feature])
+    Arturo::Feature.expects(:where).twice.returns([@feature.reload])
     Arturo::Feature.to_feature(@feature.symbol)
     Arturo::Feature.to_feature(@feature.symbol)
   end
 
   def test_ttl_expiry
     Arturo::Feature.to_feature(@feature.symbol)
-    Arturo::Feature.expects(:where).once.returns([@feature])
+    Arturo::Feature.expects(:where).once.returns([@feature.reload])
     Timecop.travel(Time.now + Arturo::Feature.cache_ttl - 5.seconds)
     Arturo::Feature.to_feature(@feature.symbol)
     Timecop.travel(Time.now + Arturo::Feature.cache_ttl + 5.seconds)


### PR DESCRIPTION
-> use .to_sym on all keys called on cache

also made all the .where stubs return what is actually coming back from AR: a feature with a string symbol
