### PR TITLE
Add Arturo::Feature.last_updated_at

### DIFF
--- a/app/models/arturo/feature.rb
+++ b/app/models/arturo/feature.rb
@@ -65,6 +65,10 @@ module Arturo
       "<Arturo::Feature #{name}, deployed to #{deployment_percentage}%>"
     end
 
+    def self.last_updated_at
+      maximum(:updated_at)
+    end
+
     protected
 
     def passes_threshold?(feature_recipient)

--- a/test/dummy_app/test/unit/feature_test.rb
+++ b/test/dummy_app/test/unit/feature_test.rb
@@ -42,6 +42,23 @@ class ArturoFeatureTest < ActiveSupport::TestCase
     assert feature.errors[:symbol].present?
   end
 
+  def test_last_updated_at
+    Timecop.travel(Time.local(2008, 9, 1, 12, 0, 0))
+    feature1 = create(:feature)
+
+    updated_at = Time.local(2011, 9, 1, 12, 0, 0)
+
+    Timecop.freeze(updated_at) do
+      feature2 = create(:feature)
+    end
+
+    assert_equal updated_at, Arturo::Feature.last_updated_at
+  end
+
+  def test_last_updated_at_with_no_features
+    assert_nil Arturo::Feature.last_updated_at
+  end
+
   # regression
   # @see https://github.com/jamesarosen/arturo/issues/7
   def test_deployment_percentage_is_not_overwritten_on_create


### PR DESCRIPTION
We'd like to cache the list of features without resorting to expiration. If we knew the last time a feature was modified, we could include that in the cache keys.
