### PR TITLE
do not return :NO_SUCH_FEATURE when caching nil

### DIFF
--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -44,8 +44,8 @@ module Arturo
         cached_feature == NO_SUCH_FEATURE ? nil : cached_feature
       else
         symbol = feature_or_symbol.to_sym
-        feature = to_feature_without_caching(symbol) || NO_SUCH_FEATURE
-        feature_cache.write(symbol, feature, :expires_in => cache_ttl)
+        feature = to_feature_without_caching(symbol)
+        feature_cache.write(symbol, feature || NO_SUCH_FEATURE, :expires_in => cache_ttl)
         feature
       end
     end

--- a/test/dummy_app/test/unit/cache_test.rb
+++ b/test/dummy_app/test/unit/cache_test.rb
@@ -44,9 +44,9 @@ class CacheTest < ActiveSupport::TestCase
 
   def test_nils_are_cached
     Arturo::Feature.expects(:where).once.returns([])
-    Arturo::Feature.to_feature(:ramen)
-    Arturo::Feature.to_feature(:ramen)
-    Arturo::Feature.to_feature(:ramen)
+    assert_nil Arturo::Feature.to_feature(:ramen)
+    assert_nil Arturo::Feature.to_feature(:ramen)
+    assert_nil Arturo::Feature.to_feature(:ramen)
   end
 
   def test_works_with_other_cache_backend


### PR DESCRIPTION
@jamesarosen fixes #43 and returns the behavior to pre-cache fix state
