### PR TITLE
test version of avtiverecord so we do not need to load Rails

### DIFF
--- a/app/models/arturo/feature.rb
+++ b/app/models/arturo/feature.rb
@@ -10,7 +10,7 @@ module Arturo
     Arturo::Feature::SYMBOL_REGEX = /^[a-zA-z][a-zA-Z0-9_]*$/
     DEFAULT_ATTRIBUTES = { :deployment_percentage => 0 }.with_indifferent_access
 
-    attr_accessible :symbol, :deployment_percentage if Rails::VERSION::MAJOR < 4
+    attr_accessible :symbol, :deployment_percentage if ActiveRecord::VERSION::MAJOR < 4
     attr_readonly :symbol
 
     validates_presence_of :symbol, :deployment_percentage


### PR DESCRIPTION
for example zendesk_core only has activerecord, not rails
@jamesarosen 
