### PR TITLE
whitelists and blacklists can be global

### DIFF
--- a/test/dummy_app/test/unit/whitelist_and_blacklist_test.rb
+++ b/test/dummy_app/test/unit/whitelist_and_blacklist_test.rb
@@ -30,8 +30,8 @@ class ArturoWhitelistAndBlacklistTest < ActiveSupport::TestCase
   end
 
   def test_lists_can_be_defined_before_feature_is_created
-    Arturo::Feature.whitelists[:does_not_exist] = lambda { |thing| thing == 'whitelisted' }
-    Arturo::Feature.blacklists[:does_not_exist] = lambda { |thing| thing == 'blacklisted' }
+    Arturo::Feature.whitelist(:does_not_exist) { |thing| thing == 'whitelisted' }
+    Arturo::Feature.blacklist(:does_not_exist) { |thing| thing == 'blacklisted' }
     @feature = create(:feature, :symbol => :does_not_exist)
     assert  feature.enabled_for?('whitelisted')
     assert !feature.enabled_for?('blacklisted')


### PR DESCRIPTION
Until now, `Feature.whitelist` and `.blacklist` took a required first argument -- the name of the feature:

``` ruby
Arturo::Feature.whitelist(:foo) do |recipient|
  recipient.plan.has_foo?
end
```

Now whitelists and blacklists can be global. The block takes the feature as the first argument:

``` ruby
Arturo::Feature.whitelist do |feature, recipient|
  recipient.plan.has?(feature.to_sym)
end
```

The former is now implemented on top of the latter.
