### PR TITLE
do not overwrite rails methods

### DIFF
--- a/app/helpers/arturo/features_helper.rb
+++ b/app/helpers/arturo/features_helper.rb
@@ -37,7 +37,7 @@ module Arturo
       content_tag(:output, value, { 'for' => id, 'class' => 'deployment_percentage no_js' })
     end
 
-    def error_messages_for(feature, attribute)
+    def error_messages_for_feature(feature, attribute)
       if feature.errors[attribute].any?
         content_tag(:ul, :class => 'errors') do
           feature.errors[attribute].map { |msg| content_tag(:li, msg, :class => 'error') }.join('').html_safe

--- a/app/views/arturo/features/_form.html.erb
+++ b/app/views/arturo/features/_form.html.erb
@@ -4,12 +4,12 @@
 
     <%= form.label(:symbol) %>
     <%= form.text_field(:symbol, :required => 'required', :pattern => Arturo::Feature::SYMBOL_REGEX.source, :class => 'symbol') %>
-    <%= error_messages_for(feature, :symbol) %>
+    <%= error_messages_for_feature(feature, :symbol) %>
 
     <%= form.label(:deployment_percentage) %>
     <%= form.range_field(:deployment_percentage, :min => '0', :max => '100', :step => '1', :class => 'deployment_percentage') %>
     <%= deployment_percentage_output_tag 'feature_deployment_percentage', feature.deployment_percentage %>
-    <%= error_messages_for(feature, :deployment_percentage) %>
+    <%= error_messages_for_feature(feature, :deployment_percentage) %>
 
     <footer><%= form.submit %></footer>
   </fieldset>

--- a/test/dummy_app/test/unit/features_helper_test.rb
+++ b/test/dummy_app/test/unit/features_helper_test.rb
@@ -26,9 +26,9 @@ class ArturoFeaturesHelperTest < ActiveSupport::TestCase
     end
   end
 
-  def test_error_messages_for
+  test "error_messages_for_feature" do
     expected = "<ul class=\"errors\"><li class=\"error\">must be less than or equal to 100</li></ul>"
-    actual = error_messages_for(bad_feature, :deployment_percentage)
+    actual = error_messages_for_feature(bad_feature, :deployment_percentage)
 
     assert_equal expected, actual
     assert actual.html_safe?


### PR DESCRIPTION
error_messages_for used to be a rails method and is in dynamic_form gem (deprecated form helpers gem)
we should not overwrite it

@jamesarosen
