### PR TITLE
fix respond_to blowing up because of extra include_all argument

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -6,8 +6,7 @@ module Arturo
   require 'arturo/feature_caching'
   require 'arturo/engine' if defined?(Rails) && Rails::VERSION::MAJOR >= 3
 
-  class <<self
-
+  class << self
     # Quick check for whether a feature is enabled for a recipient.
     # @param [String, Symbol] feature_name
     # @param [#id] recipient
@@ -16,32 +15,5 @@ module Arturo
       f = self::Feature.to_feature(feature_name)
       f && f.enabled_for?(recipient)
     end
-
-    ENABLED_FOR_METHOD_NAME = /^(\w+)_enabled_for\?$/
-
-    ENABLED_FOR_METHOD_NAME_WARNING = "Arturos FEATURE_enabled_for?(OBJECT) methods are going away, use feature_enabled_for?(FEATURE, OBJECT)"
-
-    def respond_to_missing?(symbol, include_all = false)
-      if symbol.to_s =~ ENABLED_FOR_METHOD_NAME
-        warn ENABLED_FOR_METHOD_NAME_WARNING
-        true
-      else
-        super
-      end
-    end
-
-    def respond_to?(symbol, include_all = false)
-      respond_to_missing? symbol, include_all
-    end
-
-    def method_missing(symbol, *args, &block)
-      if (args.length == 1 && match = ENABLED_FOR_METHOD_NAME.match(symbol.to_s))
-        warn ENABLED_FOR_METHOD_NAME_WARNING
-        feature_enabled_for?(match[1], args[0])
-      else
-        super(symbol, *args, &block)
-      end
-    end
-
   end
 end

--- a/test/dummy_app/test/unit/feature_test.rb
+++ b/test/dummy_app/test/unit/feature_test.rb
@@ -36,12 +36,6 @@ class ArturoFeatureTest < ActiveSupport::TestCase
     refute ::Arturo.feature_enabled_for?(:does_not_exist, 'Paula')
   end
 
-  def test_x_enabled_for
-    @feature = create(:feature, :deployment_percentage => 100, :symbol => :foo)
-    recipient = stub('User', :to_s => 'Paula', :id => 12)
-    assert ::Arturo.foo_enabled_for?(recipient), "#{feature} should be enabled for #{recipient}"
-  end
-
   def test_requires_a_symbol
     feature.symbol = nil
     refute feature.valid?


### PR DESCRIPTION
calling respond_to?(:xxx, true) on Arturo blows up, instead of fixing it, how about we just kill that feature :)

@jamesarosen
