### PR TITLE
Deprecate FEATURE_enabled_for?

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -21,13 +21,24 @@ module Arturo
 
     ENABLED_FOR_METHOD_NAME = /^(\w+)_enabled_for\?$/
 
-    def respond_to?(symbol)
-      symbol.to_s =~ ENABLED_FOR_METHOD_NAME || super(symbol)
+    ENABLED_FOR_METHOD_NAME_WARNING = "Arturos FEATURE_enabled_for?(OBJECT) methods are going away, use feature_enabled_for?(FEATURE, OBJECT)"
+
+    def respond_to_missing?(symbol, include_all = false)
+      if symbol.to_s =~ ENABLED_FOR_METHOD_NAME
+        warn ENABLED_FOR_METHOD_NAME_WARNING
+        true
+      else
+        super
+      end
+    end
+
+    def respond_to?(symbol, include_all = false)
+      respond_to_missing? symbol, include_all
     end
 
     def method_missing(symbol, *args, &block)
       if (args.length == 1 && match = ENABLED_FOR_METHOD_NAME.match(symbol.to_s))
-        warn "Arturos FEATURE_enabled_for?(OBJECT) methods are going away, use feature_enabled_for?(FEATURE, OBJECT)"
+        warn ENABLED_FOR_METHOD_NAME_WARNING
         feature_enabled_for?(match[1], args[0])
       else
         super(symbol, *args, &block)


### PR DESCRIPTION
@grosser
1. emit a deprecation warning when calling `Arturo.[FEATURE]_enabled_for?`
2. emit a deprecation warning when calling `Arturo.respond_to?` with `[FEATURE]_enabled_for?`
3. add for `Arturo.respond_to_missing?`

Includes #77
