### PR TITLE
Adding 'set_feature!' to complement 'enable_feature!' and 'disable_feature!'

### DIFF
--- a/lib/arturo/test_support.rb
+++ b/lib/arturo/test_support.rb
@@ -28,4 +28,19 @@ Arturo.instance_eval do
     end
   end
 
+  # Enable or disable a feature.  If enabling, create it if necessary.
+  # For use in testing. Not auto-required on load. To load,
+  #
+  #   require 'arturo/test_support'
+  #
+  # @param [Symbol, String] name the feature name
+  # @param Boolean enabled should the feature be enabled?
+  def set_feature!(name, enabled)
+    if enabled
+      enable_feature!(name)
+    else
+      disable_feature!(name)
+    end
+  end
+
 end


### PR DESCRIPTION
This allows you to write tests like

``` ruby
[true, false].each do |enabled|
  context "has_my_new_feature? is #{enabled}" do
    setup do
      Arturo.set_feature!(:my_new_feature, enabled)
    end

    should "return success status" do
      assert_equal enabled, @my_obj.success?
    end
  end
end
```
