### PR TITLE
Freeze string literals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,26 @@
-rvm:
-  - 2.0.0
-  - 2.1.7
-  - 2.2.3
 sudo: false
-cache: bundler
 language: ruby
+
+cache: bundler
+bundler_args: ""
+
+branches:
+  only: master
+
+rvm:
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
+
 gemfile:
-  - gemfiles/rails3_2.gemfile
-  - gemfiles/rails4_0.gemfile
-  - gemfiles/rails4_1.gemfile
-  - gemfiles/rails4_2.gemfile
-  - gemfiles/rails5_0.gemfile
-before_install: gem i bundler
-script: bundle exec rake test
+  - gemfiles/rails3.2.gemfile
+  - gemfiles/rails4.1.gemfile
+  - gemfiles/rails4.2.gemfile
+  - gemfiles/rails5.0.gemfile
+
 matrix:
   exclude:
-    - rvm: 2.0.0
-      gemfile: gemfiles/rails5_0.gemfile
-    - rvm: 2.1.7
-      gemfile: gemfiles/rails5_0.gemfile
+    - rvm: 2.3.1
+      gemfile: gemfiles/rails3.2.gemfile
+    - rvm: 2.1.9
+      gemfile: gemfiles/rails5.0.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,1 @@
-source 'https://rubygems.org'
-
-gemspec
+eval_gemfile('gemfiles/rails4.2.gemfile')

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,8 @@ Rake::TestTask.new do |t|
   t.verbose = true
 end
 
+task default: :test
+
 begin
   require 'rcov/rcovtask'
   Rcov::RcovTask.new do |test|
@@ -32,5 +34,3 @@ Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_files.include('Gemfile')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
-
-task :default => "wwtd:local"

--- a/app/controllers/arturo/features_controller.rb
+++ b/app/controllers/arturo/features_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'action_controller'
 require 'arturo/feature_params_support'
 

--- a/app/helpers/arturo/features_helper.rb
+++ b/app/helpers/arturo/features_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
   module FeaturesHelper
     include ActionView::Helpers::TagHelper

--- a/app/views/arturo/features/_feature.html.erb
+++ b/app/views/arturo/features/_feature.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <tr class='feature' id="feature_<%= feature.id %>">
   <td><code class='ruby symbol'><%= feature.symbol %></code></td>
   <td><%= deployment_percentage_range_and_output_tags("features[#{feature.id}][deployment_percentage]", feature.deployment_percentage) %></td>

--- a/app/views/arturo/features/_form.html.erb
+++ b/app/views/arturo/features/_form.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <%= form_for(feature, :as => 'feature', :url => (feature.new_record? ? arturo_engine.features_path : arturo_engine.feature_path(feature))) do |form| %>
   <fieldset>
     <legend><%= legend %></legend>

--- a/app/views/arturo/features/edit.html.erb
+++ b/app/views/arturo/features/edit.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <h2><%= t('.title', :name => @feature.name) %></h2>
 
 <%= arturo_flash_messages %>

--- a/app/views/arturo/features/forbidden.html.erb
+++ b/app/views/arturo/features/forbidden.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <h2><%= t('.title') %></h2>
 
 <%= arturo_flash_messages %>

--- a/app/views/arturo/features/index.html.erb
+++ b/app/views/arturo/features/index.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <h2><%= t('.title') %></h2>
 
 <%= arturo_flash_messages %>

--- a/app/views/arturo/features/new.html.erb
+++ b/app/views/arturo/features/new.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <h2><%= t('.title') %></h2>
 
 <%= arturo_flash_messages %>

--- a/app/views/arturo/features/show.html.erb
+++ b/app/views/arturo/features/show.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <h2><%= t('.title', :name => @feature.name) %></h2>
 
 <%= arturo_flash_messages %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Arturo::Engine.routes.draw do
   resources :features, :controller => 'arturo/features'
   put 'features', :to => 'arturo/features#update_all', :as => 'features_update_all'

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: Bundler.root.sub('/gemfiles', '')
+
+gem 'rails', '~> 3.2.18'
+gem 'minitest', '< 5'
+gem 'test-unit-minitest'

--- a/gemfiles/rails3_2.gemfile
+++ b/gemfiles/rails3_2.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "rails", "~> 3.2.18"
-gem 'minitest', "< 5"
-gem 'test-unit-minitest'

--- a/gemfiles/rails4.1.gemfile
+++ b/gemfiles/rails4.1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: Bundler.root.sub('/gemfiles', '')
+
+gem 'rails', '~> 4.1.15'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: Bundler.root.sub('/gemfiles', '')
+
+gem 'rails', '~> 4.2.6'
+gem 'responders', '~> 2.0'

--- a/gemfiles/rails4_0.gemfile
+++ b/gemfiles/rails4_0.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "rails", "4.0.6"

--- a/gemfiles/rails4_1.gemfile
+++ b/gemfiles/rails4_1.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "rails", "4.1.2"

--- a/gemfiles/rails4_2.gemfile
+++ b/gemfiles/rails4_2.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "rails", "4.2.0"
-gem "responders", "~> 2.0"

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: Bundler.root.sub('/gemfiles', '')
+
+gem 'rails', '~> 5.0.0.rc1'
+gem 'responders', '~> 2.0'

--- a/gemfiles/rails5_0.gemfile
+++ b/gemfiles/rails5_0.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gemspec :path=>"../"
-
-gem "rails", github: "rails"
-gem "arel", github: "rails/arel"
-gem "responders", "~> 2.0"

--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   require 'arturo/special_handling'

--- a/lib/arturo/controller_filters.rb
+++ b/lib/arturo/controller_filters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # Adds before filters to controllers for specifying that actions

--- a/lib/arturo/engine.rb
+++ b/lib/arturo/engine.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arturo/controller_filters'
 require 'arturo/middleware'
 

--- a/lib/arturo/feature.rb
+++ b/lib/arturo/feature.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_record'
 
 # a stub

--- a/lib/arturo/feature_availability.rb
+++ b/lib/arturo/feature_availability.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # A mixin that provides #feature_enabled? and #if_feature_enabled

--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arturo/no_such_feature'
 
 module Arturo

--- a/lib/arturo/feature_factories.rb
+++ b/lib/arturo/feature_factories.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   sequence(:feature_symbol) { |n| "feature_#{n}".to_sym }
 

--- a/lib/arturo/feature_management.rb
+++ b/lib/arturo/feature_management.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # A mixin that is included by Arturo::FeaturesController and is declared

--- a/lib/arturo/feature_params_support.rb
+++ b/lib/arturo/feature_params_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # Mix in to FeaturesController. Provides the logic for getting parameters

--- a/lib/arturo/middleware.rb
+++ b/lib/arturo/middleware.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
   # A Rack middleware that requires a feature to be present. By default,
   # checks feature availability against an `arturo.recipient` object

--- a/lib/arturo/no_such_feature.rb
+++ b/lib/arturo/no_such_feature.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # A Null-Object stand-in for a Feature.

--- a/lib/arturo/special_handling.rb
+++ b/lib/arturo/special_handling.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arturo
 
   # Adds whitelist and blacklist support to individual features by name

--- a/lib/arturo/test_support.rb
+++ b/lib/arturo/test_support.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Arturo.instance_eval do
 
   # Enable a feature; create it if necessary.

--- a/lib/generators/arturo/assets_generator.rb
+++ b/lib/generators/arturo/assets_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators'
 
 module Arturo

--- a/lib/generators/arturo/initializer_generator.rb
+++ b/lib/generators/arturo/initializer_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators'
 
 module Arturo

--- a/lib/generators/arturo/migration_generator.rb
+++ b/lib/generators/arturo/migration_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators'
 require 'rails/generators/migration'
 

--- a/lib/generators/arturo/routes_generator.rb
+++ b/lib/generators/arturo/routes_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/generators'
 
 module Arturo

--- a/lib/generators/arturo/templates/initializer.rb
+++ b/lib/generators/arturo/templates/initializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arturo'
 require 'arturo/feature'
 

--- a/lib/generators/arturo/templates/migration.rb
+++ b/lib/generators/arturo/templates/migration.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/core_ext'
 
 class CreateFeatures < ActiveRecord::Migration

--- a/test/dummy_app/app/controllers/application_controller.rb
+++ b/test/dummy_app/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   protect_from_forgery
 

--- a/test/dummy_app/app/controllers/books_controller.rb
+++ b/test/dummy_app/app/controllers/books_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class BooksController < ApplicationController
 
   require_feature :books

--- a/test/dummy_app/app/helpers/application_helper.rb
+++ b/test/dummy_app/app/helpers/application_helper.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 module ApplicationHelper
 end

--- a/test/dummy_app/app/models/user.rb
+++ b/test/dummy_app/app/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User
 
   attr_reader :name, :id

--- a/test/dummy_app/app/views/layouts/application.html.erb
+++ b/test/dummy_app/app/views/layouts/application.html.erb
@@ -1,3 +1,4 @@
+<%# frozen_string_literal: true %>
 <!DOCTYPE html>
 <html>
 <head>

--- a/test/dummy_app/config/application.rb
+++ b/test/dummy_app/config/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/test/dummy_app/config/boot.rb
+++ b/test/dummy_app/config/boot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.

--- a/test/dummy_app/config/environment.rb
+++ b/test/dummy_app/config/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load the rails application
 require File.expand_path('../application', __FILE__)
 

--- a/test/dummy_app/config/environments/development.rb
+++ b/test/dummy_app/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 

--- a/test/dummy_app/config/environments/production.rb
+++ b/test/dummy_app/config/environments/production.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 

--- a/test/dummy_app/config/environments/test.rb
+++ b/test/dummy_app/config/environments/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/environment.rb
 

--- a/test/dummy_app/config/initializers/arturo_initializer.rb
+++ b/test/dummy_app/config/initializers/arturo_initializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arturo'
 
 # Configure who may manage features here.

--- a/test/dummy_app/config/initializers/backtrace_silencers.rb
+++ b/test/dummy_app/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy_app/config/initializers/inflections.rb
+++ b/test/dummy_app/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/test/dummy_app/config/initializers/mime_types.rb
+++ b/test/dummy_app/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy_app/config/initializers/secret_token.rb
+++ b/test/dummy_app/config/initializers/secret_token.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Your secret key for verifying the integrity of signed cookies.

--- a/test/dummy_app/config/initializers/session_store.rb
+++ b/test/dummy_app/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 DummyApp::Application.config.session_store :cookie_store, :key => '_dummy_app_session'

--- a/test/dummy_app/config/routes.rb
+++ b/test/dummy_app/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 DummyApp::Application.routes.draw do
   mount Arturo::Engine => "/arturo"
 

--- a/test/dummy_app/db/migrate/20101017195547_create_features.rb
+++ b/test/dummy_app/db/migrate/20101017195547_create_features.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/core_ext'
 
 class CreateFeatures < ActiveRecord::Migration

--- a/test/dummy_app/db/schema.rb
+++ b/test/dummy_app/db/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to

--- a/test/dummy_app/db/seeds.rb
+++ b/test/dummy_app/db/seeds.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 #

--- a/test/dummy_app/test/functional/controller_filters_test.rb
+++ b/test/dummy_app/test/functional/controller_filters_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class ArturoControllerFiltersTest < ActionController::TestCase

--- a/test/dummy_app/test/functional/features_controller_admin_test.rb
+++ b/test/dummy_app/test/functional/features_controller_admin_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 require 'arturo/features_controller'
 
@@ -18,7 +19,7 @@ class ArturoFeaturesControllerAdminTest < Arturo::IntegrationTest
     get "/arturo/features"
     assert_response :success
     assert_select 'table tbody tr input[type=range]'
-    assert_select 'table tfoot a[href=?]', '/arturo/features/new'
+    assert_select "table tfoot a[href='/arturo/features/new']"
     assert_select 'table tfoot input[type=submit]'
   end
 

--- a/test/dummy_app/test/functional/features_controller_non_admin_test.rb
+++ b/test/dummy_app/test/functional/features_controller_non_admin_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 require 'arturo/features_controller'
 

--- a/test/dummy_app/test/prepare_database.rb
+++ b/test/dummy_app/test/prepare_database.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_record'
 
 ActiveRecord::Base.establish_connection(

--- a/test/dummy_app/test/test_helper.rb
+++ b/test/dummy_app/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV["RAILS_ENV"] = "test"
 require 'bundler/setup'
 

--- a/test/dummy_app/test/unit/cache_test.rb
+++ b/test/dummy_app/test/unit/cache_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 require 'arturo/features_helper'
 

--- a/test/dummy_app/test/unit/engine_test.rb
+++ b/test/dummy_app/test/unit/engine_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class EngineTest < ActiveSupport::TestCase

--- a/test/dummy_app/test/unit/feature_availability_test.rb
+++ b/test/dummy_app/test/unit/feature_availability_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 require 'arturo/features_helper'
 

--- a/test/dummy_app/test/unit/feature_test.rb
+++ b/test/dummy_app/test/unit/feature_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class ArturoFeatureTest < ActiveSupport::TestCase

--- a/test/dummy_app/test/unit/features_helper_test.rb
+++ b/test/dummy_app/test/unit/features_helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 require 'arturo/features_helper'
 require 'rails-dom-testing'

--- a/test/dummy_app/test/unit/middleware_test.rb
+++ b/test/dummy_app/test/unit/middleware_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class MiddlewareTest < ActiveSupport::TestCase

--- a/test/dummy_app/test/unit/no_such_feature_test.rb
+++ b/test/dummy_app/test/unit/no_such_feature_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class NoSuchFeatureTest < ActiveSupport::TestCase

--- a/test/dummy_app/test/unit/whitelist_and_blacklist_test.rb
+++ b/test/dummy_app/test/unit/whitelist_and_blacklist_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../../test_helper', __FILE__)
 
 class ArturoWhitelistAndBlacklistTest < ActiveSupport::TestCase


### PR DESCRIPTION
:octopus::computer:

/cc @grosser 

### Description
 * Simplified .travis.yml
 * Changed the gemfiles to match usual conventions
 * Drop Ruby 2.0 and Rails 4.0
 * Add Ruby 2.3
 * Add frozen string literal
 * Remove Rails 3.2/Ruby 2.3 because it's trying to modify a frozen string.

### Steps to merge
* [ ] :+1: from the team

### Risks
* Low: error on ruby 2.3 trying to modifying a frozen string