### PR TITLE
Verify if helper is defined for Rails 5 API mode

### DIFF
--- a/lib/arturo/engine.rb
+++ b/lib/arturo/engine.rb
@@ -6,9 +6,11 @@ module Arturo
   class Engine < ::Rails::Engine
     ActiveSupport.on_load(:action_controller) do
       include Arturo::FeatureAvailability
-      helper  Arturo::FeatureAvailability
       include Arturo::ControllerFilters
-      helper  Arturo::FeatureManagement
+      if respond_to?(:helper)
+        helper  Arturo::FeatureAvailability
+        helper  Arturo::FeatureManagement
+      end
     end
 
     root = File.expand_path("../../..", __FILE__)


### PR DESCRIPTION
:octopus::computer:

/cc @grosser @bquorning 

### Description
Fails if you include the gem in a Rails 5 application in API mode.

### Steps to merge
* [ ] :+1: from the team

### Risks
* None