### PR TITLE
update uniqueness validator

### DIFF
--- a/lib/arturo/feature.rb
+++ b/lib/arturo/feature.rb
@@ -15,7 +15,7 @@ module Arturo
     attr_readonly :symbol
 
     validates_presence_of :symbol, :deployment_percentage
-    validates_uniqueness_of :symbol, :allow_blank => true
+    validates_uniqueness_of :symbol, :allow_blank => true, :case_sensitive => false
     validates_numericality_of :deployment_percentage,
                                             :only_integer => true,
                                             :allow_blank => true,


### PR DESCRIPTION
### Description

This does not fail in Rails 6.0 but will fail in Rails 6.1

There are dependent gems that fail specs due to `config.active_support.deprecations :raise` and rather than updating those gems to remove this configuration, we are updating `arturo` uniqueness validator to include the `case_sensitive` flag.

Will need to merge [112](https://github.com/zendesk/arturo/pull/112) first

### References 
JIRA: https://zendesk.atlassian.net/browse/WALR-2077
Issue: https://github.com/rails/rails/commit/9def05385f1cfa41924bb93daa187615e88c95b9

### Risks 
**Low**