### PR TITLE
Using the gem in a non-rails environment (but with AR)

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -5,7 +5,7 @@ module Arturo
   require 'arturo/feature_availability'
   require 'arturo/feature_management'
   require 'arturo/feature_caching'
-  require 'arturo/engine'
+  require 'arturo/engine' if defined?(Rails)
 
   class << self
     # Quick check for whether a feature is enabled for a recipient.


### PR DESCRIPTION
@bquorning internally we had be using the gem in a non rails app with ActiveRecord being the ORM. The changes in 2.5.2 broke this for us. I have changed the line which is of concern to us. Feel free to comment and contact me through other channels to discuss this.
