### PR TITLE
[EM-7115] Explicitly require rails engine - part of MPQ sentry migration

### DIFF
--- a/lib/arturo/engine.rb
+++ b/lib/arturo/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'arturo/controller_filters'
 require 'arturo/middleware'
+require 'rails/engine'
 
 module Arturo
   class Engine < ::Rails::Engine


### PR DESCRIPTION
**Description:** 

Explicitly require rails engine to avoid errors that `::Rails::Engine` cannot be found.

We discovered this error while working on migrating the the MPQ service to use Sentry:

```sh
[mail_parsing_queue /app (mariozaizar/EM-7115)] ➔ bundle exec rake test
/bundle/ruby/2.6.0/gems/active_record_host_pool-1.0.3/lib/active_record_host_pool/connection_adapter_mixin.rb:95: warning: method redefined; discarding old establish_connection
/bundle/ruby/2.6.0/gems/activerecord-5.2.6.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:973: warning: previous definition of establish_connection was here
/bundle/ruby/2.6.0/gems/zendesk_database_support-1.44.3/lib/zendesk_database_support/account_master_reconnection.rb:52: warning: method redefined; discarding old active?
/bundle/ruby/2.6.0/gems/activerecord-5.2.6.2/lib/active_record/connection_adapters/mysql2_adapter.rb:89: warning: previous definition of active? was here
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/settings.rb:134: warning: method redefined; discarding old logger=
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/options.rb:44: warning: previous definition of logger= was here
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/settings.rb:213: warning: method redefined; discarding old runtime_metrics
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/options.rb:41: warning: previous definition of runtime_metrics was here
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/settings.rb:358: warning: method redefined; discarding old tracer
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/options.rb:41: warning: previous definition of tracer was here
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/settings.rb:402: warning: method redefined; discarding old tracer=
/bundle/ruby/2.6.0/gems/ddtrace-0.54.2/lib/ddtrace/configuration/options.rb:44: warning: previous definition of tracer= was here
/bundle/ruby/2.6.0/gems/zendesk_arturo-0.12.0/lib/zendesk_arturo.rb:98: warning: `*' interpreted as argument prefix
/bundle/ruby/2.6.0/gems/arturo-2.5.3/lib/arturo/engine.rb:6:in `<module:Arturo>': uninitialized constant Rails::Engine (NameError)
	from /bundle/ruby/2.6.0/gems/arturo-2.5.3/lib/arturo/engine.rb:5:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/arturo-2.5.3/lib/arturo.rb:8:in `<module:Arturo>'
	from /bundle/ruby/2.6.0/gems/arturo-2.5.3/lib/arturo.rb:2:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/zendesk_arturo-0.12.0/lib/zendesk_arturo.rb:5:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/models/accounts/url.rb:4:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/models/account.rb:10:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/factories/account_factory.rb:3:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/factories.rb:19:in `block in load_core_factories'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/factories.rb:19:in `each'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/factories.rb:19:in `load_core_factories'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/core_models_helper.rb:20:in `load_factories'
	from /bundle/ruby/2.6.0/gems/zendesk_core-7.8.0/lib/zendesk/testing/core_models_helper.rb:27:in `setup'
	from /app/test/helper.rb:18:in `<top (required)>'
	from /app/test/account/capability/accessors_test.rb:3:in `require_relative'
	from /app/test/account/capability/accessors_test.rb:3:in `<top (required)>'
	from /bundle/ruby/2.6.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `require'
	from /bundle/ruby/2.6.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /bundle/ruby/2.6.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `select'
	from /bundle/ruby/2.6.0/gems/rake-13.0.6/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
Command failed with status (1)
```

**References:** 

- Related MPQ PR: https://github.com/zendesk/zendesk_mail_parsing_queue/pull/1237