### PR TITLE
Drop Ruby 2.4, 2.5 and Rails 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,42 +10,38 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.4'
-          - '2.5'
           - '2.6'
           - '2.7'
         gemfile:
-          - rails4.2
           - rails5.0
           - rails5.1
           - rails5.2
           - rails6.0
           - rails6.1
-        exclude:
-          - ruby-version: '2.6'
-            gemfile: rails4.2
-          - ruby-version: '2.7'
-            gemfile: rails4.2
-          - ruby-version: '2.4'
-            gemfile: rails6.0
-          - ruby-version: '2.4'
-            gemfile: rails6.1
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v2
+      - uses: zendesk/checkout@v3
       - name: Set up Ruby
         uses: zendesk/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler: 1
-        if: ${{ matrix.gemfile == 'rails4.2' }}
-      - name: Set up Ruby
-        uses: zendesk/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-        if: ${{ matrix.gemfile != 'rails4.2' }}
       - run: bundle install --jobs 4
       - name: RSpec
         run: bundle exec rspec
+
+  specs_successful:
+    name: Specs passing?
+    needs: specs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ needs.specs.result == 'success' }}
+          then
+            echo "All specs pass"
+          else
+            echo "Some specs failed"
+            false
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Drop support for Rails 4.2
+
+Drop support for Ruby 2.4 & 2.5
+
 ## v2.5.4
 
 Bug fix: Explicitly require rails engine to avoid errors that ::Rails::Engine cannot be found.

--- a/arturo.gemspec
+++ b/arturo.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.description = 'Deploy features incrementally to your users'
 
   s.license = 'APLv2'
-  s.required_ruby_version = '>= 2.1'
+  s.required_ruby_version = '>= 2.6'
 
-  s.add_runtime_dependency      'activerecord', '>= 4.2', '< 6.2'
+  s.add_runtime_dependency      'activerecord', '>= 5.0', '< 6.2'
 
-  s.add_development_dependency  'rails',        '>= 4.2', '< 6.2'
+  s.add_development_dependency  'rails',        '>= 5.0', '< 6.2'
   s.add_development_dependency  'sqlite3'
   s.add_development_dependency  'rspec-rails'
   s.add_development_dependency  'factory_bot'

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'rails', '~> 4.2.6'
-gem 'responders', '~> 2.0'
-gem 'sqlite3', '~> 1.3.6'

--- a/lib/arturo/controller_filters.rb
+++ b/lib/arturo/controller_filters.rb
@@ -14,7 +14,7 @@ module Arturo
     end
 
     def on_feature_disabled(feature_name)
-      render (Rails::VERSION::MAJOR < 5 ? :text : :plain) => 'Forbidden', :status => 403
+      render :plain => 'Forbidden', :status => 403
     end
 
     module ClassMethods

--- a/spec/controllers/controller_filters_spec.rb
+++ b/spec/controllers/controller_filters_spec.rb
@@ -17,20 +17,14 @@ describe BooksController, type: :controller do
   end
 
   it 'works with a get on show' do
-    if Rails::VERSION::MAJOR < 5
-      get :show, id: '2'
-    else
-      get :show, params: { id: '2' }
-    end
+    get :show, params: { id: '2' }
+
     expect(response).to be_successful
   end
 
   it 'works with a post on holds' do
-    if Rails::VERSION::MAJOR < 5
-      post :holds, id: '3'
-    else
-      post :holds, params: { id: '3' }
-    end
+    post :holds, params: { id: '3' }
+
     expect(response).to have_http_status(:forbidden)
   end
 

--- a/spec/controllers/features_controller_admin_spec.rb
+++ b/spec/controllers/features_controller_admin_spec.rb
@@ -37,11 +37,7 @@ describe Arturo::FeaturesController, type: :request do
       }
     }
 
-    if Rails::VERSION::MAJOR < 5
-      put '/arturo/features', params
-    else
-      put '/arturo/features', params: params
-    end
+    put '/arturo/features', params: params
 
     expect(features.first.reload.deployment_percentage.to_s).to eq('14')
     expect(features.last.reload.deployment_percentage.to_s).to eq('98')
@@ -54,11 +50,8 @@ describe Arturo::FeaturesController, type: :request do
   end
 
   it 'responds to a post on create' do
-    if Rails::VERSION::MAJOR < 5
-      post '/arturo/features', feature: { symbol: 'anything' }
-    else
-      post '/arturo/features', params: { feature: { symbol: 'anything' } }
-    end
+    post '/arturo/features', params: { feature: { symbol: 'anything' } }
+
     expect(Arturo::Feature.find_by_symbol('anything')).to be_present
     expect(response).to redirect_to('/arturo/features')
   end
@@ -74,20 +67,13 @@ describe Arturo::FeaturesController, type: :request do
   end
 
   def test_put_update
-    if Rails::VERSION::MAJOR < 5
-      put "/arturo/features/#{@features.first.id}", feature: { deployment_percentage: '2' }
-    else
-      put "/arturo/features/#{@features.first.id}", params: { feature: { deployment_percentage: '2' } }
-    end
+    put "/arturo/features/#{@features.first.id}", params: { feature: { deployment_percentage: '2' } }
+
     expect(response).to redirect_to("/arturo/features/#{@features.first.to_param}")
   end
 
   def test_put_invalid_update
-    if Rails::VERSION::MAJOR < 5
-      put '/arturo/features/#{@features.first.id}', feature: { deployment_percentage: '-10' }
-    else
-      put '/arturo/features/#{@features.first.id}', params: { feature: { deployment_percentage: '-10' } }
-    end
+    put '/arturo/features/#{@features.first.id}', params: { feature: { deployment_percentage: '-10' } }
 
     expect(response).to be_success
     expect(controller.flash[:alert])

--- a/spec/controllers/features_controller_non_admin_spec.rb
+++ b/spec/controllers/features_controller_non_admin_spec.rb
@@ -20,11 +20,8 @@ describe Arturo::FeaturesController, type: :request do
   end
 
   it 'returns forbidden with post on create' do
-    if Rails::VERSION::MAJOR < 5
-      post '/arturo/features', feature: { deployment_percentage: '38' }
-    else
-      post '/arturo/features', params: { feature: { deployment_percentage: '38' } }
-    end
+    post '/arturo/features', params: { feature: { deployment_percentage: '38' } }
+
     expect(response).to have_http_status(:forbidden)
   end
 
@@ -39,11 +36,8 @@ describe Arturo::FeaturesController, type: :request do
   end
 
   it 'returns forbidden with put on update' do
-    if Rails::VERSION::MAJOR < 5
-      put '/arturo/features/1', feature: { deployment_percentage: '81' }
-    else
-      put '/arturo/features/1', params: { feature: { deployment_percentage: '81' } }
-    end
+    put '/arturo/features/1', params: { feature: { deployment_percentage: '81' } }
+
     expect(response).to have_http_status(:forbidden)
   end
 

--- a/spec/dummy_app/app/controllers/books_controller.rb
+++ b/spec/dummy_app/app/controllers/books_controller.rb
@@ -4,24 +4,22 @@ class BooksController < ApplicationController
   require_feature :books
   require_feature :book_holds, :only => :holds
 
-  PLAIN_TEXT_RENDERER = (Rails::VERSION::MAJOR < 5 ? :text : :plain)
-
   # instead of a model:
   BOOKS = {}
 
   def show
     if (book = requested_book)
-      render PLAIN_TEXT_RENDERER => book
+      render :plain => book
     else
-      render PLAIN_TEXT_RENDERER => 'Not Found', :status => 404
+      render :plain => 'Not Found', :status => 404
     end
   end
 
   def holds
     if (book = requested_book)
-      render PLAIN_TEXT_RENDERER => "Added hold on #{book}"
+      render :plain => "Added hold on #{book}"
     else
-      render PLAIN_TEXT_RENDERER => 'Not Found', :status => 404
+      render :plain => 'Not Found', :status => 404
     end
   end
 

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -12,7 +12,6 @@ module DummyApp
     config.filter_parameters += [:password]
     config.assets.precompile += %w( arturo.js )
     config.action_controller.action_on_unpermitted_parameters = :raise
-    config.active_record.raise_in_transactional_callbacks = true if Rails::VERSION::MAJOR < 5
     config.active_support.deprecation = :raise
     config.secret_key_base = 'dsdsdshjdshdshdshdshjdhjshjsdhjdsjhdshjds'
     config.i18n.enforce_available_locales = true


### PR DESCRIPTION
It also simplfies the CI. Configuring GitHub to have many required tests is hard to maintain.

In fact, the admin needs to duplicate what is defined in the actions.yml test matrix. It should be quite a bit easier this way, just having one CI job that depends on the success of the entire test matrix.