### PR TITLE
Add support for Rails 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           - rails5.2
           - rails6.0
           - rails6.1
+          - rails7.0
+        exclude:
+          - {ruby-version: '2.6', gemfile: rails7.0}
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/app/controllers/arturo/features_controller.rb
+++ b/app/controllers/arturo/features_controller.rb
@@ -14,7 +14,6 @@ module Arturo
     include Arturo::FeatureManagement
     include Arturo::FeatureParamsSupport
 
-    unloadable
     respond_to :html, :json, :xml
 
     if respond_to?(:before_action)

--- a/arturo.gemspec
+++ b/arturo.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.license = 'APLv2'
   s.required_ruby_version = '>= 2.6'
 
-  s.add_runtime_dependency      'activerecord', '>= 5.0', '< 6.2'
+  s.add_runtime_dependency      'activerecord', '>= 5.0', '< 7.1'
 
-  s.add_development_dependency  'rails',        '>= 5.0', '< 6.2'
+  s.add_development_dependency  'rails',        '>= 5.0', '< 7.1'
   s.add_development_dependency  'sqlite3'
   s.add_development_dependency  'rspec-rails'
   s.add_development_dependency  'factory_bot'

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec path: Bundler.root.sub('/gemfiles', '')
+
+gem 'rails', '~> 7.0.0'
+gem 'responders', '~> 3.0'
+gem 'sqlite3', '~> 1.4'

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -10,7 +10,7 @@ module DummyApp
   class Application < Rails::Application
     config.encoding = "utf-8"
     config.filter_parameters += [:password]
-    config.assets.precompile += %w( arturo.js )
+    config.assets.precompile += %w( arturo.js ) if config.respond_to?(:assets)
     config.action_controller.action_on_unpermitted_parameters = :raise
     config.active_support.deprecation = :raise
     config.secret_key_base = 'dsdsdshjdshdshdshdshjdhjshjsdhjdsjhdshjds'


### PR DESCRIPTION
Rails 7.0 is only compatible with Ruby 2.7+ so we don't test it with Ruby 2.6

`unloadable` was moved in Rails but I opted to just remove it from `app/controllers/arturo/features_controller.rb`. That will affect the `development` environment but I don't really think it's much of an impact.