### PR TITLE
Release v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v2.6.0
+
+Add support for Rails 7.0
+
 Add support for Ruby 3.0 & 3.1
 
 Drop support for Rails 4.2

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '2.5.4'
+  VERSION = '2.6.0'
 end


### PR DESCRIPTION
- Adds support for Ruby 3.0 & 3.1 #125
- Add support for Rails 7.0  #124
- Drops support for Ruby 2.4, 2.5, and 4.2 #123