### PR TITLE
Release v2.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,27 +10,16 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '2.6'
           - '2.7'
           - '3.0'
           - '3.1'
+          - '3.2'
         gemfile:
-          - rails5.0
-          - rails5.1
-          - rails5.2
           - rails6.0
           - rails6.1
           - rails7.0
-        exclude:
-          - {ruby-version: '2.6', gemfile: rails7.0}
-          - {ruby-version: '3.0', gemfile: rails5.0}
-          - {ruby-version: '3.0', gemfile: rails5.1}
-          - {ruby-version: '3.0', gemfile: rails5.2}
-          - {ruby-version: '3.0', gemfile: rails6.0}
-          - {ruby-version: '3.1', gemfile: rails5.0}
-          - {ruby-version: '3.1', gemfile: rails5.1}
-          - {ruby-version: '3.1', gemfile: rails5.2}
-          - {ruby-version: '3.1', gemfile: rails6.0}
+        include:
+          - {ruby-version: '2.7', gemfile: rails5.2}
     name: Ruby ${{ matrix.ruby-version }}, ${{ matrix.gemfile }}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v2.8.0
+
+Drop support for Ruby 2.6
+
+Drop Support for Rails 5.0 & 5.1
+
+Add support for Ruby 3.2
+
 ## v2.7.0
 
 Adds ability to register cache update listeners with Arturo::FeatureCaching::AllStrategy that are called when the cache is updated

--- a/arturo.gemspec
+++ b/arturo.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
   s.description = 'Deploy features incrementally to your users'
 
   s.license = 'APLv2'
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 2.7'
 
-  s.add_runtime_dependency      'activerecord', '>= 5.0', '< 7.1'
+  s.add_runtime_dependency      'activerecord', '>= 5.2', '< 7.1'
 
-  s.add_development_dependency  'rails',        '>= 5.0', '< 7.1'
+  s.add_development_dependency  'rails',        '>= 5.2', '< 7.1'
   s.add_development_dependency  'sqlite3'
   s.add_development_dependency  'rspec-rails'
   s.add_development_dependency  'factory_bot'

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'rails', '~> 5.0.0'
-gem 'responders', '~> 2.0'
-gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '../'
-
-gem 'rails', '~> 5.1.0'
-gem 'responders', '~> 2.0'

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '2.7.0'
+  VERSION = '2.8.0'
 end


### PR DESCRIPTION
- Drops Ruby 2.6
- Drops Rails 5.0 & 5.1
- Test with Ruby 3.2