### PR TITLE
build cache hash using each_with_object

### DIFF
--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -102,7 +102,7 @@ module Arturo
         #   without cache extension option
         #
         def arturos_from_origin(fallback:)
-          Arturo::Feature.all.each_with_object({}) { |f, hash| hash[f.symbol.to_sym] = f }
+          Arturo::Feature.all.to_h { |f| [f.symbol.to_sym, f] }
         rescue ActiveRecord::ActiveRecordError
           raise unless Arturo::Feature.extend_cache_on_failure?
 

--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -102,7 +102,7 @@ module Arturo
         #   without cache extension option
         #
         def arturos_from_origin(fallback:)
-          Hash[Arturo::Feature.all.map { |f| [f.symbol.to_sym, f] }]
+          Arturo::Feature.all.each_with_object({}) { |f, hash| hash[f.symbol.to_sym] = f }
         rescue ActiveRecord::ActiveRecordError
           raise unless Arturo::Feature.extend_cache_on_failure?
 


### PR DESCRIPTION
Instead of creating a temporary array with all Arturos only to convert it into a hash immediately, we should be building this hash directly. This will save (a little bit of) memory (as we will not be creating an unnecessary array). 

It also seems to be slightly faster: 

```ruby
require "benchmark/ips"
require 'random/formatter'

class Feature
  attr_reader :symbol, :data

  def initialize
    @symbol = Random.alphanumeric(10)
    @data = { Random.alphanumeric(3) => Random.alphanumeric(10) }
  end
end

class Test
  attr_reader :features

  def initialize
    @features = Array.new(1000) { |_index| Feature.new }
  end

  def old
    Hash[features.map { |f| [f.symbol.to_sym, f] }]
  end

  def new
    features.each_with_object({}) { |f, hash| hash[f.symbol.to_sym] = f }
  end
end

test = Test.new
Benchmark.ips do |x|
  x.report("previous, with an intermediary array") { test.old }
  x.report("new, with each_with_object") { test.new }
  x.compare!
end
```

The results of which are:

```
Calculating -------------------------------------
previous, with an intermediary array
                          3.848k (± 9.8%) i/s -     19.104k in   5.018458s
new, with each_with_object
                          4.760k (± 6.4%) i/s -     23.944k in   5.054193s

Comparison:
new, with each_with_object:     4759.7 i/s
previous, with an intermediary array:     3847.6 i/s - 1.24x  slower

```

This is Ruby 3.2.2, 2019 Macbook Pro with the 6-Core Intel Core i7 and 32GB of RAM, Ventura 13.5.2.