### PR TITLE
bring back warm_cache! method

### DIFF
--- a/lib/arturo/feature_caching.rb
+++ b/lib/arturo/feature_caching.rb
@@ -57,7 +57,7 @@ module Arturo
     end
 
     def warm_cache!
-      warn "Deprecated, no longer necessary!"
+      to_feature(:fake_feature_to_force_cache_warming)
     end
 
     class AllStrategy


### PR DESCRIPTION
To force a cache load during startup, some services at Zendesk have resorted to making a fake query in an initializer (`Arturo::Feature.find_feature "smth")`. This method will make this intent more explicit and readable.