### PR TITLE
Rename feature to feature_methods, reformat

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
-module Arturo
-  require 'arturo/null_logger'
-  require 'arturo/special_handling'
-  require 'arturo/feature'
-  require 'arturo/feature_availability'
-  require 'arturo/feature_management'
-  require 'arturo/feature_caching'
-  require 'arturo/engine' if defined?(Rails)
 
+require_relative 'arturo/null_logger'
+require_relative 'arturo/special_handling'
+require_relative 'arturo/feature_methods'
+require_relative 'arturo/feature_availability'
+require_relative 'arturo/feature_management'
+require_relative 'arturo/feature_caching'
+require_relative 'arturo/engine' if defined?(Rails)
+
+module Arturo
   class << self
     # Quick check for whether a feature is enabled for a recipient.
     # @param [String, Symbol] feature_name

--- a/lib/arturo/feature_methods.rb
+++ b/lib/arturo/feature_methods.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'active_record'
 require 'active_support'
 

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
This commit renames `arturo/feature` to `arturo/feature_methods`. The reason for this is that we expect to have an `Arturo::Feature` class which collides with the filename of `arturo/feature` in the library. This causes problems with `zeitwerk` and `require`.

The module we define in `arturo/feature` is actually called `FeatureMethods` so this name change makes it more consistent with the contents.

This also changes `require` to `require_relative` and moves the require out of the module and to the top of the file.