### PR TITLE
return false immediately for nil recipients

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -15,6 +15,8 @@ module Arturo
     # @param [#id] recipient
     # @return [true,false] whether the feature exists and is enabled for the recipient
     def feature_enabled_for?(feature_name, recipient)
+      return false if recipient.nil?
+
       f = self::Feature.to_feature(feature_name)
       f && f.enabled_for?(recipient)
     end

--- a/spec/models/feature_spec.rb
+++ b/spec/models/feature_spec.rb
@@ -36,6 +36,11 @@ describe Arturo::Feature do
     expect(::Arturo.feature_enabled_for?(:does_not_exist, 'Paula')).to be(false)
   end
 
+  it 'does not find feature for nil recipients' do
+    expect(::Arturo.feature_enabled_for?(feature.symbol, nil)).to be(false)
+    expect(::Arturo.feature_enabled_for?(:does_not_exist, nil)).to be(false)
+  end
+
   it 'requires a symbol' do
     feature.symbol = nil
     expect(feature).to_not be_valid


### PR DESCRIPTION
For recipients that do not exist, we return `false` (this is also documented in the README). We can skip building the `Feature` object and potentially fetching data and return false immediately.