### PR TITLE
stop loading arturo/engine automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+Stops loading the Rails engine automatically. If you are using the engine, you need to require it explicitly by adding `require 'arturo/engine'` to `application.rb`.
+
 ## v3.0.0
 
 Converts the Feature model into a mixin that should be used by services via a model generator.

--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -6,7 +6,6 @@ require_relative 'arturo/feature_methods'
 require_relative 'arturo/feature_availability'
 require_relative 'arturo/feature_management'
 require_relative 'arturo/feature_caching'
-require_relative 'arturo/engine' if defined?(Rails)
 
 module Arturo
   class << self

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -3,6 +3,7 @@ require File.expand_path('../boot', __FILE__)
 
 require 'bundler/setup'
 require 'rails/all'
+require 'arturo/engine'
 
 Bundler.require(:default, Rails.env) if defined?(Bundler)
 


### PR DESCRIPTION
Applications that don’t use `FeaturesController` to manage Arturo features don’t need to automatically load the whole engine. Engine loading should be an explicit decision on an app’s part.