### PR TITLE
bring back autoloading engine, drop autoload manipulations

### DIFF
--- a/lib/arturo.rb
+++ b/lib/arturo.rb
@@ -6,6 +6,7 @@ require_relative 'arturo/feature_methods'
 require_relative 'arturo/feature_availability'
 require_relative 'arturo/feature_management'
 require_relative 'arturo/feature_caching'
+require_relative 'arturo/engine' if defined?(Rails)
 
 module Arturo
   class << self

--- a/lib/arturo/engine.rb
+++ b/lib/arturo/engine.rb
@@ -13,9 +13,5 @@ module Arturo
         helper  Arturo::FeatureManagement
       end
     end
-
-    root = File.expand_path("../../..", __FILE__)
-    config.autoload_paths = ["#{root}/app/helpers", "#{root}/app/controllers"]
-    config.eager_load_paths = []
   end
 end

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '4.0.0'
+  VERSION = '3.0.2.pre.1'
 end

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -3,7 +3,6 @@ require File.expand_path('../boot', __FILE__)
 
 require 'bundler/setup'
 require 'rails/all'
-require 'arturo/engine'
 
 Bundler.require(:default, Rails.env) if defined?(Bundler)
 


### PR DESCRIPTION
The change we made in https://github.com/zendesk/arturo/pull/141 was a mistake: loading the engine is necessary not only for the `FeaturesController`, but for other areas of Arturo as well. This PR rolls back the change and fixes the autoload problem differently.

When the Arturo engine is loaded, we set `autoload_paths` and `eager_load_paths`. This is not something a gem should be doing: if unavoidable, this values should be appended to, not completely replaced. So, in this PR we get rid of these lines.

 In my testing in a small Rails app, this removal doesn’t affect the controller working: if the engine is mounted in `routes.rb`, we still can access the Arturos page and edit features.