### PR TITLE
Require debug

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 ENV['RAILS_ENV'] = 'test'
+require 'debug/prelude'
+require 'debug/config'
 require 'dummy_app/config/environment'
 require 'rspec/rails'
 require 'factory_bot'


### PR DESCRIPTION
In #146 I added the debug gem but forgot to require it. `config` is particularly necessary to load your settings from your `.rdbgrc` file.