### PR TITLE
Release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+## v4.1.0
+
+Removes upper boundary on ActiveRecord.
+
+Drops support for Ruby < 3.0.
+
+Drops support for Rails < 6.0.
+
 ## v4.0.1
 
 Fixes loading issues for apps not using the Rails engine.

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '4.0.1'
+  VERSION = '4.1.0'
 end


### PR DESCRIPTION
- Removes upper bounder on ActiveRecord.
- Drops support for Ruby < 3.0.
- Drops support for Rails < 6.0.