### PR TITLE
require indifferent_access extension explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## v4.1.1
+
+Fixes missing indifferent_access import
+
 ## v4.1.0
 
 Removes upper boundary on ActiveRecord.

--- a/lib/arturo/feature_methods.rb
+++ b/lib/arturo/feature_methods.rb
@@ -2,6 +2,7 @@
 
 require 'active_record'
 require 'active_support'
+require 'active_support/core_ext/hash/indifferent_access'
 
 module Arturo
   module FeatureMethods

--- a/lib/arturo/version.rb
+++ b/lib/arturo/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arturo
-  VERSION = '4.1.0'
+  VERSION = '4.1.1'
 end


### PR DESCRIPTION
In the model-to-mixin rework for Arturo 3.0, we changed the load order, and this extension might not always get loaded before the `FeatureMethods` module. This doesn’t happen in Arturo’s own tests, but affects gems that depend on Arturo.