### PR TITLE
stop requiring bump

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'bundler/setup'
 require 'bundler/gem_tasks'
-require 'bump/tasks'
 
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)


### PR DESCRIPTION
We have removed bump as a dependency in https://github.com/zendesk/arturo/commit/e644d0527e0110eeec22b14af046d0ab0d73ec6c, but still required it in the `Rakefile` which caused all rake tasks to fail.