### PR TITLE
clear whitelists and blacklists after running their specs

### DIFF
--- a/spec/models/whitelist_and_blacklist_spec.rb
+++ b/spec/models/whitelist_and_blacklist_spec.rb
@@ -10,6 +10,11 @@ describe 'Whilelist and Blacklist' do
     Arturo::Feature.blacklists.clear
   end
 
+  after do
+    Arturo::Feature.whitelists.clear
+    Arturo::Feature.blacklists.clear
+  end
+
   it 'overrides percent calculation with whitelist' do
     feature.deployment_percentage = 0
     Arturo::Feature.whitelist(feature.symbol) { |thing| true }


### PR DESCRIPTION
The `'works with a post on holds'` spec in `controller_filters_spec.rb` was flaky. In it, we check that if a feature `:book_holds` has `deployment_percentage` set to 0, and we call require_feature `:book_holds` in a controller, then we receive 403 Forbidden from that controller.

However, if the `'works with global whitelisting'` spec ran as a final spec from its suite of six, and before the `:book_holds`, we still had a whitelist in place that would enable all features, so `enabled_for?` returned true for :book_holds:

```ruby
def enabled_for?(feature_recipient)
  return false if feature_recipient.nil?
  return false if blacklisted?(feature_recipient)
  ---> return true if  whitelisted?(feature_recipient) # returned true, so we never checked deployment_percentage
  passes_threshold?(feature_recipient, deployment_percentage || 0)
end
```

This suggests that approximately 1/12 of all spec runs should see this spec fail (the probability of the global whitelist spec being last is 1/6, and the probability of it running before the controller spec is 1/2), which agrees with the recent data: in a matrix of 16, one job was usually failing.

The solution to this problem is to clean whitelists (and blacklists) not only before their specs, but also after.
