### PR TITLE
stop checking for before_filter

### DIFF
--- a/app/controllers/arturo/features_controller.rb
+++ b/app/controllers/arturo/features_controller.rb
@@ -16,13 +16,8 @@ module Arturo
 
     respond_to :html, :json, :xml
 
-    if respond_to?(:before_action)
-      before_action :require_permission
-      before_action :load_feature, :only => [ :show, :edit, :update, :destroy ]
-    else
-      before_filter :require_permission
-      before_filter :load_feature, :only => [ :show, :edit, :update, :destroy ]
-    end
+    before_action :require_permission
+    before_action :load_feature, :only => [ :show, :edit, :update, :destroy ]
 
     def index
       @features = Arturo::Feature.all

--- a/lib/arturo/controller_filters.rb
+++ b/lib/arturo/controller_filters.rb
@@ -20,8 +20,7 @@ module Arturo
     module ClassMethods
 
       def require_feature(name, options = {})
-        method = respond_to?(:before_action) ? :before_action : :before_filter
-        send(method, options) do |controller|
+        send(:before_action, options) do |controller|
           unless controller.feature_enabled?(name)
             controller.on_feature_disabled(name)
           end


### PR DESCRIPTION
`before_filter` got deprecated in Rails 5.1, and we only support Rails 6.0 and above, so there is no need to check whether we need it or `before_action`.