### PR TITLE
Fix Rails Main testing, only test with latest Ruby

### DIFF
--- a/.github/workflows/rails_main_specs.yml
+++ b/.github/workflows/rails_main_specs.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Rails Main Specs
 
 on:
   schedule:
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - '3.1'
-          - '3.2'
           - "3.3"
         gemfile:
           - rails_main

--- a/gemfiles/common.rb
+++ b/gemfiles/common.rb
@@ -3,7 +3,6 @@
 gemspec path: '../'
 
 gem 'debug'
-gem 'sqlite3', '~> 1.4'
 gem 'rspec-rails'
 gem 'factory_bot'
 gem 'timecop'

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -4,3 +4,4 @@ eval_gemfile 'common.rb'
 
 gem 'rails', '~> 6.0.0'
 gem 'responders', '~> 3.0'
+gem 'sqlite3', '~> 1.4'

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -4,3 +4,4 @@ eval_gemfile 'common.rb'
 
 gem 'rails', '~> 7.1.0'
 gem 'responders', '~> 3.0'
+gem 'sqlite3', '~> 1.4'

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -4,3 +4,4 @@ eval_gemfile 'common.rb'
 
 gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'responders', '~> 3.0'
+gem "sqlite3", "~> 2"


### PR DESCRIPTION
ActiveRecord now requires sqlite3 >= 2.0[^1]. Also, we test with Rails main every day and it seems wasteful to test it with Ruby 3.1 & 3.2 when 3.3 should be sufficient.

[^1]:(https://github.com/rails/rails/blob/171c4e4d377d9653a79d38c94bdfadf1a2c4c312/activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb#L14)